### PR TITLE
Add syntax highlight for comments and code inside html tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.0] - 2024-03-21
+
+- Added syntax highlighting for Textwire comments. For example, `{{-- This is a comment --}}`
+- Added syntax highlighting for Textwire code inside HTML tags. For example, `<div {{ attr.raw() }}></div>`
+
 ## [1.1.0] - 2024-03-19
 
 - Fix highlighting with directives and comments that touch html. For example, `@end<div>` or `@endHere is HTML`

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,4 +1,10 @@
 {
+    "comments": {
+        "blockComment": [
+            "{{--",
+            "--}}"
+        ],
+    },
     "brackets": [],
     "autoClosingPairs": [
         ["[", "]"],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "textwire",
     "displayName": "Textwire",
     "description": "Textwire templating language support for VSCode",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "homepage": "https://github.com/textwire/vscode-textwire/blob/main/README.md",
     "pricing": "Free",
     "engines": {

--- a/syntaxes/textwire.tmLanguage.json
+++ b/syntaxes/textwire.tmLanguage.json
@@ -7,8 +7,9 @@
         { "include": "text.html.basic" }
     ],
     "injections": {
-        "text.html.basic.tw": {
+        "text.html.basic.tw - (comment.block.tw), L:(text.html.basic.tw - comment.block.tw), L:(source.js.embedded.html - comment.block.tw)": {
             "patterns": [
+                { "include": "#comments" },
                 { "include": "#expression" },
                 { "include": "#directives" }
             ]
@@ -106,6 +107,17 @@
         "variables": {
             "name": "variable.other.tw",
             "match": "\\b\\w+\\b"
+        },
+        "comments": {
+            "begin": "{{--",
+            "beginCaptures": {
+                "0": { "name": "punctuation.definition.comment.begin.tw" }
+            },
+            "end": "--}}",
+            "endCaptures": {
+                "0": { "name": "punctuation.definition.comment.end.tw" }
+            },
+            "name": "comment.block.tw"
         }
     }
 }


### PR DESCRIPTION
- Added syntax highlighting for Textwire comments. For example, `{{-- This is a comment --}}`
- Added syntax highlighting for Textwire code inside HTML tags. For example, `<div {{ attr.raw() }}></div>`