### PR TITLE
fix: highlight inside HTML attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.1] - 2024-03-23
+
+- Fixed highlighting dots array brackets, object brackets and other elements inside HTML attributes. They used to be highlighted as strings. For example `<input type="{{ obj.prop }}">`
+
 ## [1.2.0] - 2024-03-21
 
 - Added syntax highlighting for Textwire comments. For example, `{{-- This is a comment --}}`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "textwire",
     "displayName": "Textwire",
     "description": "Textwire templating language support for VSCode",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "homepage": "https://github.com/textwire/vscode-textwire/blob/main/README.md",
     "pricing": "Free",
     "engines": {

--- a/syntaxes/textwire.tmLanguage.json
+++ b/syntaxes/textwire.tmLanguage.json
@@ -17,8 +17,11 @@
     },
     "repository": {
         "expression": {
+            "name": "keyword.tw",
             "begin": "(?<![\\\\{]){{",
-            "beginCaptures": { "0": { "name": "support.function.construct.begin.tw" } },
+            "beginCaptures": {
+                "0": { "name": "support.function.construct.begin.tw" }
+            },
             "end": "}}",
             "endCaptures": { "0": { "name": "support.function.construct.begin.tw" } },
             "patterns": [ { "include": "#language" } ]
@@ -31,6 +34,7 @@
                 { "include": "#keywords" },
                 { "include": "#arrays" },
                 { "include": "#objects" },
+                { "include": "#commas" },
                 { "include": "#variables" }
             ]
         },
@@ -85,10 +89,10 @@
         },
         "numbers": {
             "name": "constant.numeric.tw",
-            "match": "\\b(?:\\d+(?:\\.\\d+)?|0x[0-9a-fA-F]+)\\b"
+            "match": "\\b[\\d.]+\\b"
         },
         "functions": {
-            "begin": "(\\.(len|raw|split|trim|float|int) ?\\()",
+            "begin": "((len|raw|split|trim|float|int) ?\\()",
             "beginCaptures": { "0": { "name": "entity.name.function.member.tw" } },
             "end": "\\)",
             "endCaptures": { "0": { "name": "entity.name.function.member.tw" } },
@@ -106,7 +110,7 @@
         },
         "variables": {
             "name": "variable.other.tw",
-            "match": "\\b\\w+\\b"
+            "match": "\\b\\w+\\.?\\b"
         },
         "comments": {
             "begin": "{{--",
@@ -118,6 +122,10 @@
                 "0": { "name": "punctuation.definition.comment.end.tw" }
             },
             "name": "comment.block.tw"
+        },
+        "commas": {
+            "name": "variable.other.tw",
+            "match": ","
         }
     }
 }


### PR DESCRIPTION
- Fixed highlighting dots array brackets, object brackets and other elements inside HTML attributes. They used to be highlighted as strings. For example `<input type="{{ obj.prop }}">`